### PR TITLE
[ bug-3460 -> dev ] Changing password fields from TextboxElement to ProtectedTextboxElement

### DIFF
--- a/src/components/auth/loginForm.tsx
+++ b/src/components/auth/loginForm.tsx
@@ -1,6 +1,6 @@
 import React, {FormEvent} from 'react'
 import { Field } from 'redux-form';
-import { TextboxElement, ButtonElement } from '@reperio/ui-components';
+import { TextboxElement, ButtonElement, ProtectedTextboxElement } from '@reperio/ui-components';
 
 const rowMargin = "4em";
 
@@ -22,7 +22,7 @@ export const LoginFormFields = (props: {navigateToForgotPassword(): void}) => (
         </div>
         <div className="row">
             <div className="r-row-child">
-                <Field name="password" placeholder="Password" type="password" component={TextboxElement} />
+                <Field name="password" placeholder="Password" type="password" component={ProtectedTextboxElement} />
             </div>
         </div>
         <div className="row">

--- a/src/components/resetPassword/resetPasswordForm.tsx
+++ b/src/components/resetPassword/resetPasswordForm.tsx
@@ -1,6 +1,6 @@
 import React, {FormEvent} from 'react'
 import { Field } from 'redux-form';
-import { TextboxElement, ButtonElement } from '@reperio/ui-components';
+import { TextboxElement, ButtonElement, ProtectedTextboxElement } from '@reperio/ui-components';
 
 const rowMargin = "4em";
 
@@ -17,12 +17,12 @@ export const ResetPasswordFormFields = () => (
     <>
         <div className="row">
             <div className="r-row-child">
-                <Field name="password" placeholder="Enter New Password" type="password" component={TextboxElement} />
+                <Field name="password" placeholder="Enter New Password" type="password" component={ProtectedTextboxElement} />
             </div>
         </div>
         <div className="row">
             <div className="r-row-child">
-                <Field name="confirmPassword" placeholder="Confirm New Password" type="password" component={TextboxElement} />
+                <Field name="confirmPassword" placeholder="Confirm New Password" type="password" component={ProtectedTextboxElement} />
             </div>
         </div>
         <div className="row">


### PR DESCRIPTION
[Target Process](https://sevenhillstechnology.tpondemand.com/entity/3460-reperio-auth-password-field-not-hiding)

After the update to add a max width, password fields appeared in plain text rather than hidden. Updating password fields on login and password reset pages to use ui-components `ProtectedTextboxElement` which uses the HTML password type.